### PR TITLE
Update Scanner class variable to public

### DIFF
--- a/src/com/nintendods/core/CommandParser.java
+++ b/src/com/nintendods/core/CommandParser.java
@@ -5,7 +5,7 @@ import com.nintendods.util.Util;
 import java.util.Scanner;
 
 public class CommandParser {
-    private final Scanner scn;
+    public final Scanner scn;
 
     public CommandParser() {
         scn = new Scanner(System.in);


### PR DESCRIPTION
-for the scanner class, i need the variable to be public to access nextInt()
-i cant use the readInt() method in CommandParser for input as 
      1) it needs to have range for input
      2) every input will have a arrow sign '>' in front of it, so for my case i have 2 input in single line to represent the edge so the arrow sign will be doubled the amount of 
          needed